### PR TITLE
Replace 'void main' with 'int main'.

### DIFF
--- a/eh/ihateeh.cxx
+++ b/eh/ihateeh.cxx
@@ -164,7 +164,7 @@ A test() {
   return a1 + A() + a2 + A() + a3 + a4;
 }
 
-void main() {
+int main() {
   int i;
 
   /* Call test(), with a different ctor/dtor throwing each time */

--- a/seh/xcpt4u.c
+++ b/seh/xcpt4u.c
@@ -923,7 +923,7 @@ VOID Test88(_Inout_ PLONG Counter)
   finally { *Counter += 1; }
 }
 
-VOID main(int argc, char *argv[])
+int main(int argc, char *argv[])
 
 {
 


### PR DESCRIPTION
The C and C++ standards require that main be defined with a return type
of 'int'.  Some compilers permit 'void' as an extension but clang makes
this a hard error.
