### PR TITLE
Dereferencing null is UB.

### DIFF
--- a/eh/terminate.cpp
+++ b/eh/terminate.cpp
@@ -30,7 +30,7 @@ public:
         if (FGenSEHException)
         {
             printf("generating access violation (SEH)\n");
-            *(char*)(0) = 0; // Uh, EHa, don't you think?
+            *(volatile char*)(0) = 0; // Uh, EHa, don't you think?
         }
         else
         {


### PR DESCRIPTION
Change the load to a volatile load to stop the compiler from reasoning
about it's behavior.
